### PR TITLE
chore(helm): bump to 3.13.3

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ branding:
 inputs:
   helm-version:
     description: "helm version"
-    default: "3.13.0"
+    default: "3.13.3"
     required: false
   helmfile-version:
     description: "helmfile version"


### PR DESCRIPTION
Bumping to resolve [this upstream issue](https://github.com/helm/helm/issues/12449) which is currently blocking the `safe-settings` deployment